### PR TITLE
Fixed an issue with system not going to sleep after screen is locked

### DIFF
--- a/Counting Sheep.wdgt/Scripts/Controller.js
+++ b/Counting Sheep.wdgt/Scripts/Controller.js
@@ -76,17 +76,15 @@ var Controller = {
     Properties.seconds = 0;
     View.seconds.value = '00';
   },
-  // Handler for widget.system(), when putting system to sleep
-  "widgetSystemHandler" : function (command) {
-    if (command.outputString[3] === "4")
-      widget.system("/usr/bin/osascript -e 'tell application \"Finder\" to sleep'", null);
-	else
-	  widget.system("/usr/bin/pmset sleepnow", null);
-  },
   "timeUp" : function () {
     if (false)
       widget.system("/usr/bin/osascript -e 'tell application \"Finder\" to shut down'", null);
     else
-      widget.system("/usr/bin/sw_vers -productVersion", Controller.widgetSystemHandler);
+      widget.system("/usr/bin/osascript -e 'set productVersion to do shell script \"sw_vers -productVersion\"\n" +
+      										 "if item 4 of productVersion = \"4\" then\n" +
+      											"\ttell application \"Finder\" to sleep\n" +
+      										"else\n" +
+      											"\tdo shell script \"pmset sleepnow\"\n" +
+      										"end if'", null);
   }
 }

--- a/Counting Sheep.wdgt/Scripts/Controller.js
+++ b/Counting Sheep.wdgt/Scripts/Controller.js
@@ -6,27 +6,27 @@ var Controller = {
       Properties.hours = 0;
     else
       Properties.hours = View.hours.value;
-    
+
     // Get minutes
     if (Properties.minutes.length == 0)
       Properties.minutes = 0;
     else
       Properties.minutes = View.minutes.value;
-    
+
     // Get seconds
     if (Properties.seconds.length == 0)
       Properties.seconds  = 0;
     else
       Properties.seconds = View.seconds.value;
-    
+
     // Calculate time in seconds
     Properties.time = Properties.hours*3600 + Properties.minutes*60 + Properties.seconds*1;
     // Start countdown unless total time is <= 0
     if (Properties.time > 0)
       Properties.countdown = window.setInterval('Controller.countdown()',1000);
-    
+
     View.blurInputs();
-    
+
     return false;
   },
   // Act on stop of countdown
@@ -37,7 +37,7 @@ var Controller = {
     else { // #todo
       Controller.setToZero();
     }
-    
+
     return false;
   },
   // Countdown one second
@@ -76,10 +76,17 @@ var Controller = {
     Properties.seconds = 0;
     View.seconds.value = '00';
   },
+  // Handler for widget.system(), when putting system to sleep
+  "widgetSystemHandler" : function (command) {
+    if (command.outputString[3] === "4")
+      widget.system("/usr/bin/osascript -e 'tell application \"Finder\" to sleep'", null);
+	else
+	  widget.system("/usr/bin/pmset sleepnow", null);
+  },
   "timeUp" : function () {
     if (false)
       widget.system("/usr/bin/osascript -e 'tell application \"Finder\" to shut down'", null);
     else
-      widget.system("/usr/bin/osascript -e 'tell application \"Finder\" to sleep'", null);
+      widget.system("/usr/bin/sw_vers -productVersion", Controller.widgetSystemHandler);
   }
 }


### PR DESCRIPTION
Using Counting Sheep v1.2 I realized my Mac would not go to sleep after the screen was locked/the screen went to sleep and required password activation. The problem is that

```tell application "Finder" to sleep

``````
will not work on Mac OS Snow Leopard and Lion (I only tested it on Lion, but I also found a [post confirming the issue on 10.6](http://hints.macworld.com/article.php?story=20100424161727333)) after the screen is locked. The command

```pmset sleepnow
``````

does the trick, but is not supported on Mac OS Tiger ([man pmset](http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/10.4/man1/pmset.1.html)).

So I used 

```sw_vers -productVersion

```
to solve for x in Mac OS 10.x ([man sw_vers](http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man1/sw_vers.1.html)) first and then act accordingly.
```
